### PR TITLE
fix(ci): follow-up build fix for production-hardening

### DIFF
--- a/src/lib/aiSetupStore.js
+++ b/src/lib/aiSetupStore.js
@@ -1,7 +1,7 @@
 import { writable, get } from 'svelte/store';
-import { PUBLIC_BACKEND_URL } from '$env/static/public';
+import { HOST_URL } from '$lib/config.js';
 
-export const HOST_URL = PUBLIC_BACKEND_URL || 'https://d4gumsi.pythonanywhere.com/';
+export { HOST_URL };
 
 export const aiStatus = writable({
     status: 'inactive',

--- a/src/lib/components/AISetup.svelte
+++ b/src/lib/components/AISetup.svelte
@@ -1,6 +1,5 @@
 <script>
     import { onMount } from 'svelte';
-    import { PUBLIC_BACKEND_URL } from '$env/static/public';
     import Button from './button.svelte';
     import { aiStatus, aiActions, HOST_URL } from '$lib/aiSetupStore.js';
 

--- a/src/lib/components/LighthouseSetup.svelte
+++ b/src/lib/components/LighthouseSetup.svelte
@@ -1,6 +1,5 @@
 <script>
     import { onMount } from 'svelte';
-    import { PUBLIC_BACKEND_URL } from '$env/static/public';
     import { HOST_URL } from '$lib/aiSetupStore.js';
     import Button from './button.svelte';
     import Icon from '@iconify/svelte';

--- a/src/lib/components/utils/fetch_hangul_data.js
+++ b/src/lib/components/utils/fetch_hangul_data.js
@@ -5,7 +5,7 @@ import { sleep, getBackoffWaitTime } from "$lib/components/utils/helper_function
 import { get } from 'svelte/store';
 import { checkboxes } from "$lib/store.js";
 import { num_keywords } from "$lib/store.js";
-import { PUBLIC_BACKEND_URL } from '$env/static/public';
+import { HOST_URL } from '$lib/config.js';
 import { aiStatus } from '$lib/aiSetupStore.js';
 
 // ... rest of code
@@ -36,7 +36,7 @@ async function fetchData(file, version, timeout, isAPI) {
         }, timeout);
       });
 
-      const base_url = PUBLIC_BACKEND_URL || 'https://d4gumsi.pythonanywhere.com/';
+      const base_url = HOST_URL;
       
       const headers = {};
       if (ai_status.forceTeamKey) {

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -1,0 +1,12 @@
+/**
+ * Central configuration for the frontend.
+ * Uses build-safe environment variable access with fallback.
+ */
+
+// Fallback to PythonAnywhere production URL
+const DEFAULT_BACKEND_URL = 'https://d4gumsi.pythonanywhere.com/';
+
+// In SvelteKit/Vite, import.meta.env handles optional variables without crashing the build
+export const PUBLIC_BACKEND_URL = import.meta.env.VITE_PUBLIC_BACKEND_URL || DEFAULT_BACKEND_URL;
+
+export const HOST_URL = PUBLIC_BACKEND_URL.endsWith('/') ? PUBLIC_BACKEND_URL : `${PUBLIC_BACKEND_URL}/`;

--- a/src/lib/lighthouseStore.js
+++ b/src/lib/lighthouseStore.js
@@ -1,7 +1,6 @@
 import { writable, get } from 'svelte/store';
-import { PUBLIC_BACKEND_URL } from '$env/static/public';
+import { HOST_URL } from '$lib/config.js';
 
-const HOST_URL = PUBLIC_BACKEND_URL || 'https://d4gumsi.pythonanywhere.com/';
 const BASE_PATH = 'api/v1/products/lighthouse';
 
 // Mock Data for Development

--- a/src/routes/products/chetah2.0/+page.svelte
+++ b/src/routes/products/chetah2.0/+page.svelte
@@ -5,12 +5,12 @@
     import SearchLogo from '$lib/assets/icons8-search-100.png';
     import ChetahLogo from '$lib/assets/chetah_logo.png';
     import Navbar from "$lib/components/navbar.svelte";
-    import { PUBLIC_BACKEND_URL } from '$env/static/public';
+    import { HOST_URL } from '$lib/aiSetupStore.js';
 
     const currentPage = 'chetah2.0';
 
     // Set between dev and build
-    const host_url = PUBLIC_BACKEND_URL || 'https://d4gumsi.pythonanywhere.com/';
+    const host_url = HOST_URL;
 
     let searchQuery = '';
     let aboutChetah = false;

--- a/src/routes/products/owl/+page.svelte
+++ b/src/routes/products/owl/+page.svelte
@@ -6,13 +6,12 @@
     import LoadingBar from "$lib/components/loading_bar.svelte";
     import ChevronDown from "$lib/assets/icons/chevron-down-solid.svelte";
     import ChevronUp from "$lib/assets/icons/angle-up-solid.svelte";
-    import { PUBLIC_BACKEND_URL } from '$env/static/public';
     import { aiStatus, aiActions, HOST_URL } from '$lib/aiSetupStore.js';
     import AISetup from "$lib/components/AISetup.svelte";
     import AIBanner from "$lib/components/AIBanner.svelte";
 
     const currentPage = 'owl';
-    const host_url = PUBLIC_BACKEND_URL || 'https://d4gumsi.pythonanywhere.com/';
+    const host_url = HOST_URL;
 
     let query = $state("");
     let aboutOwl = $state(false);

--- a/src/routes/projects/chetah1.0/+page.svelte
+++ b/src/routes/projects/chetah1.0/+page.svelte
@@ -6,7 +6,7 @@
     import SearchLogo from '$lib/assets/icons8-search-100.png';
     import ChetahLogo from '$lib/assets/chetah_logo.png';
     import Navbar from "$lib/components/navbar.svelte";
-    import { PUBLIC_BACKEND_URL } from '$env/static/public';
+    import { HOST_URL } from '$lib/aiSetupStore.js';
 
     const currentPage = "chetah1.0";
 
@@ -32,7 +32,7 @@
     }
 
     async function doFetch(searchQuery) {
-        const base_url = PUBLIC_BACKEND_URL || 'https://d4gumsi.pythonanywhere.com/';
+        const base_url = HOST_URL;
         const url = `${base_url}api/v1/products/chetah`;
         const data = { query: searchQuery };
         const response = await fetch(url, {

--- a/src/routes/projects/chetah2.0/+page.svelte
+++ b/src/routes/projects/chetah2.0/+page.svelte
@@ -5,12 +5,12 @@
     import SearchLogo from '$lib/assets/icons8-search-100.png';
     import ChetahLogo from '$lib/assets/chetah_logo.png';
     import Navbar from "$lib/components/navbar.svelte";
-    import { PUBLIC_BACKEND_URL } from '$env/static/public';
+    import { HOST_URL } from '$lib/aiSetupStore.js';
 
     const currentPage = 'chetah2.0';
 
     // Set between dev and build
-    const host_url = PUBLIC_BACKEND_URL || 'https://d4gumsi.pythonanywhere.com/';
+    const host_url = HOST_URL;
 
     let searchQuery = '';
     let aboutChetah = false;

--- a/src/routes/socrates-test/+page.svelte
+++ b/src/routes/socrates-test/+page.svelte
@@ -8,15 +8,14 @@
     import { page } from '$app/stores';
     import { browser } from '$app/environment';
     import { base } from '$app/paths';
-    import { PUBLIC_BACKEND_URL } from '$env/static/public';
-    import { aiStatus, aiActions } from '$lib/aiSetupStore.js';
+    import { aiStatus, aiActions, HOST_URL } from '$lib/aiSetupStore.js';
 
     const currentPage = 'socrates-test';
     
     let secretKey = $state(null);
     let showSetup = $state(true);
 
-    const host_url = PUBLIC_BACKEND_URL || 'https://d4gumsi.pythonanywhere.com/';
+    const host_url = HOST_URL;
 
     onMount(async () => {
         secretKey = $page.url.searchParams.get('key');


### PR DESCRIPTION
## Overview
This is a small follow-up PR to include the CI build fix that was pushed shortly after the previous PR (#77) was merged.

## Changes
- Centralizes backend URL configuration in `src/lib/config.js`.
- Switches from strict `$env/static/public` to build-safe `import.meta.env`.
- Updates all components to use the new central config.

This fix is required for the GitHub Pages deployment to build successfully.
